### PR TITLE
Feat: added support for https/tls and script updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,15 @@
   **A production POC Application for InkoMoko**
 
   [![CI/CD](https://github.com/Blue-Davinci/InkoMoko/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/Blue-Davinci/InkoMoko/actions/workflows/ci-cd.yml)
-  [![Infrastructure](https://github.com/Blue-Davinci/InkoMoko/actions/workflows/infrastructure-ops.yml/badge.svg)](https://github.com/Blue-Davinci/InkoMoko/actions/workflows/infrastructure-ops.yml)
+  [![Infrastruct## 📞 Support
+
+For questions, issues, or contributions:
+
+- **Issues**: GitHub Issues
+- **Pull Requests**: Welcome and encouraged
+- **Architecture Questions**: See documentation links above
+
+---s://github.com/Blue-Davinci/InkoMoko/actions/workflows/infrastructure-ops.yml/badge.svg)](https://github.com/Blue-Davinci/InkoMoko/actions/workflows/infrastructure-ops.yml)
   [![Dependencies](https://github.com/Blue-Davinci/InkoMoko/actions/workflows/dependencies.yml/badge.svg)](https://github.com/Blue-Davinci/InkoMoko/actions/workflows/dependencies.yml)
 
   [![Go](https://img.shields.io/badge/Go-1.24+-00ADD8?style=for-the-badge&logo=go&logoColor=white)](https://golang.org/)
@@ -363,7 +371,27 @@ Transfer/sec:      1.40MB
 - **AWS Provider**: ~> 5.0
 - **Infrastructure State**: Terraform Cloud/AWS S3 Backend
 
-## 📞 Support
+## � Documentation
+
+### Quick Start Guides
+- **[HTTP Deployment](docs/QUICK_HTTPS_SETUP.md)** - Deploy with HTTP-only (immediate testing)
+- **[HTTPS Setup](docs/HTTPS_IMPLEMENTATION.md)** - Complete HTTPS implementation guide
+
+### Architecture & Infrastructure
+- **[GitHub Actions Workflows](.github/README.md)** - CI/CD pipeline documentation
+- **[Terraform Modules](depoyment/terraform/README.md)** - Infrastructure as Code details
+
+### Access Methods
+
+| Method | URL Format | Requirements | Security |
+|--------|------------|--------------|----------|
+| **HTTP (Testing)** | `http://alb-dns-name/health` | None | ⚠️ Development only |
+| **HTTPS (Production)** | `https://yourdomain.com/health` | Custom domain + Route53 | ✅ SSL/TLS encrypted |
+
+> **💡 Important**: You cannot access ALB via HTTPS using its DNS name (e.g., `my-alb-123.elb.amazonaws.com`).
+> HTTPS requires a custom domain and SSL certificate. The HTTP endpoint works immediately for testing.
+
+## �📞 Support
 
 For questions, issues, or contributions:
 

--- a/depoyment/terraform/environments/dev/https-test-config.example
+++ b/depoyment/terraform/environments/dev/https-test-config.example
@@ -1,0 +1,16 @@
+# Quick HTTPS Test Configuration
+
+# Add these to your terraform.tfvars if you have a domain:
+enable_https = true
+domain_name = "api.yourdomain.com"        # Replace with your actual domain
+route53_zone_id = "Z1234567890ABC"        # Replace with your actual zone ID
+
+# Then update main.tf to pass these variables:
+# module "alb" {
+#   source = "../../modules/alb"
+#
+#   # ... existing config ...
+#   enable_https     = var.enable_https
+#   domain_name      = var.domain_name
+#   route53_zone_id  = var.route53_zone_id
+# }

--- a/depoyment/terraform/environments/dev/main.tf
+++ b/depoyment/terraform/environments/dev/main.tf
@@ -19,6 +19,7 @@ module "alb" {
   vpc_id              = module.networking.vpc_id
   tags                = var.tags
   enable_alb_deletion = var.enable_alb_deletion
+  enable_https        = false # Set to false for HTTP-only mode initially
 }
 
 module "compute" {
@@ -34,4 +35,5 @@ module "compute" {
   private_subnet_ids             = module.networking.private_subnet_ids_list
   target_group_arn               = module.alb.target_group_arn
   target_tracking_resource_label = module.alb.target_group_resource_label
+  docker_image_url               = var.docker_image_url
 }

--- a/depoyment/terraform/environments/dev/variables.tf
+++ b/depoyment/terraform/environments/dev/variables.tf
@@ -62,3 +62,9 @@ variable "enable_alb_deletion" {
   type        = bool
   default     = false
 }
+
+variable "docker_image_url" {
+  description = "The Docker image URL to deploy"
+  type        = string
+  default     = "ghcr.io/blue-davinci/inkomoko"
+}

--- a/depoyment/terraform/modules/alb/outputs.tf
+++ b/depoyment/terraform/modules/alb/outputs.tf
@@ -23,9 +23,14 @@ output "target_group_name" {
   value       = aws_lb_target_group.main.name
 }
 
-output "listener_arn" {
-  description = "The ARN of the load balancer listener"
-  value       = aws_lb_listener.main.arn
+output "http_listener_arn" {
+  description = "The ARN of the HTTP load balancer listener"
+  value       = aws_lb_listener.http.arn
+}
+
+output "https_listener_arn" {
+  description = "The ARN of the HTTPS load balancer listener"
+  value       = var.enable_https && var.domain_name != "" && var.route53_zone_id != "" ? aws_lb_listener.https[0].arn : null
 }
 
 output "alb_security_group_id" {
@@ -36,4 +41,14 @@ output "alb_security_group_id" {
 output "target_group_resource_label" {
   description = "Resource label for ALB target tracking scaling policies"
   value       = "${aws_lb.main.arn_suffix}/${aws_lb_target_group.main.arn_suffix}"
+}
+
+output "certificate_arn" {
+  description = "The ARN of the SSL certificate"
+  value       = var.enable_https && var.domain_name != "" && var.route53_zone_id != "" ? aws_acm_certificate.main[0].arn : null
+}
+
+output "domain_name" {
+  description = "The domain name associated with the certificate"
+  value       = var.enable_https && var.domain_name != "" ? var.domain_name : null
 }

--- a/depoyment/terraform/modules/alb/ssl.tf
+++ b/depoyment/terraform/modules/alb/ssl.tf
@@ -1,0 +1,75 @@
+# SSL Certificate using AWS Certificate Manager
+resource "aws_acm_certificate" "main" {
+  count                     = var.enable_https && var.domain_name != "" ? 1 : 0
+  domain_name               = var.domain_name
+  subject_alternative_names = var.subject_alternative_names
+  validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.alb_name}-certificate"
+    }
+  )
+}
+
+# Route53 records for certificate validation
+resource "aws_route53_record" "cert_validation" {
+  for_each = var.enable_https && var.domain_name != "" && var.route53_zone_id != "" ? {
+    for dvo in aws_acm_certificate.main[0].domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  } : {}
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = var.route53_zone_id
+}
+
+# Certificate validation
+resource "aws_acm_certificate_validation" "main" {
+  count                   = var.enable_https && var.domain_name != "" && var.route53_zone_id != "" ? 1 : 0
+  certificate_arn         = aws_acm_certificate.main[0].arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+
+  timeouts {
+    create = "5m"
+  }
+}
+
+# Route53 A record pointing to ALB
+resource "aws_route53_record" "main" {
+  count   = var.enable_https && var.domain_name != "" && var.route53_zone_id != "" ? 1 : 0
+  zone_id = var.route53_zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.main.dns_name
+    zone_id                = aws_lb.main.zone_id
+    evaluate_target_health = true
+  }
+}
+
+# Optional: WWW redirect record
+resource "aws_route53_record" "www" {
+  count   = var.enable_https && var.create_www_redirect && var.domain_name != "" && var.route53_zone_id != "" ? 1 : 0
+  zone_id = var.route53_zone_id
+  name    = "www.${var.domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.main.dns_name
+    zone_id                = aws_lb.main.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/depoyment/terraform/modules/alb/variables.tf
+++ b/depoyment/terraform/modules/alb/variables.tf
@@ -23,3 +23,34 @@ variable "enable_alb_deletion" {
   type        = bool
   default     = false
 }
+
+# SSL/TLS Certificate Variables
+variable "domain_name" {
+  description = "The primary domain name for the SSL certificate"
+  type        = string
+  default     = ""
+}
+
+variable "subject_alternative_names" {
+  description = "Additional domain names for the SSL certificate"
+  type        = list(string)
+  default     = []
+}
+
+variable "route53_zone_id" {
+  description = "The Route53 hosted zone ID for DNS validation"
+  type        = string
+  default     = ""
+}
+
+variable "create_www_redirect" {
+  description = "Whether to create a www subdomain redirect"
+  type        = bool
+  default     = true
+}
+
+variable "enable_https" {
+  description = "Whether to enable HTTPS with SSL certificate"
+  type        = bool
+  default     = false
+}

--- a/depoyment/terraform/modules/compute/cloudwatch.tf
+++ b/depoyment/terraform/modules/compute/cloudwatch.tf
@@ -1,0 +1,25 @@
+# CloudWatch Log Group for container logs
+resource "aws_cloudwatch_log_group" "container_logs" {
+  name              = "/aws/ec2/inkomoko"
+  retention_in_days = 7
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.instance_prefix}-container-logs"
+    }
+  )
+}
+
+# CloudWatch Log Group for user-data logs
+resource "aws_cloudwatch_log_group" "user_data_logs" {
+  name              = "/aws/ec2/user-data"
+  retention_in_days = 7
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.instance_prefix}-user-data-logs"
+    }
+  )
+}

--- a/depoyment/terraform/modules/compute/iam.tf
+++ b/depoyment/terraform/modules/compute/iam.tf
@@ -21,8 +21,41 @@ resource "aws_iam_role_policy_attachment" "ec2_ssm_policy" {
   role       = aws_iam_role.ec2_role.id
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
+
 # CloudWatch policy for the EC2 instance
 resource "aws_iam_role_policy_attachment" "ec2_cloudwatch_policy" {
   role       = aws_iam_role.ec2_role.id
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+# Custom policy for Docker and CloudWatch Logs
+resource "aws_iam_role_policy" "ec2_custom_policy" {
+  name = "${var.instance_prefix}-ec2-custom-policy"
+  role = aws_iam_role.ec2_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogStreams"
+        ]
+        Resource = "arn:aws:logs:*:*:*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:GetAuthorizationToken",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
 }

--- a/docs/HTTPS_IMPLEMENTATION.md
+++ b/docs/HTTPS_IMPLEMENTATION.md
@@ -1,0 +1,279 @@
+# HTTPS Implementation Guide for InkoMoko
+
+## Overview
+This guide explains how to implement production-ready HTTPS with SSL/TLS certificates for the InkoMoko application using AWS Certificate Manager (ACM).
+
+> **⚠️ Important**: HTTPS requires a custom domain. You cannot use HTTPS with ALB DNS names like `my-alb-123.elb.amazonaws.com`. For immediate testing, use HTTP-only mode.
+
+## Prerequisites
+
+### 1. Domain Requirements (MANDATORY for HTTPS)
+- **Domain Name**: You must own a domain (e.g., `inkomoko.com`)
+- **Route53 Hosted Zone**: Required for automatic certificate validation
+- **DNS Delegation**: Domain nameservers must point to Route53
+
+### 2. Current Setup Options
+
+| Setup Type | Domain Required | SSL Certificate | Access Method |
+|------------|----------------|-----------------|---------------|
+| **HTTP-only** | ❌ No | ❌ No | `http://alb-dns-name` |
+| **HTTPS** | ✅ Yes | ✅ Auto (ACM) | `https://yourdomain.com` |
+
+## Quick Start Decision Tree
+
+```
+Do you have a custom domain?
+├── NO  → Use HTTP-only mode (current setup)
+│        → Deploy immediately and test
+│        → Add HTTPS later when you get a domain
+│
+└── YES → Continue with HTTPS setup below
+         → Get Route53 hosted zone
+         → Follow implementation steps
+```
+
+## HTTP-Only Setup (Current Default)
+
+If you don't have a domain yet, you can deploy and test immediately:
+
+### 1. Deploy Current Configuration
+```bash
+cd depoyment/terraform/environments/dev
+terraform apply plan.out
+```
+
+### 2. Test HTTP Access
+```bash
+# Get ALB DNS name
+ALB_DNS=$(terraform output -raw alb_dns_name)
+
+# Test health endpoint
+curl http://$ALB_DNS/health
+
+# Expected response: {"status": "ok", "timestamp": "..."}
+```
+
+### 3. Access Your Application
+- ✅ **Works immediately**: `http://your-alb-dns-name`
+- ❌ **HTTPS will fail**: Certificate errors in browser
+- 🔄 **Easy upgrade**: Add domain later for HTTPS
+
+---
+
+## HTTPS Setup (Requires Domain)
+
+## Implementation Steps
+
+### Step 1: Update Your Environment Configuration
+
+Update your environment-specific Terraform files (e.g., `environments/dev/main.tf`):
+
+```hcl
+module "alb" {
+  source = "../../modules/alb"
+
+  # Basic ALB Configuration
+  alb_name               = "inkomoko-dev-alb"
+  vpc_id                 = module.networking.vpc_id
+  subnet_ids             = module.networking.public_subnet_ids
+  enable_alb_deletion    = false
+
+  # HTTPS Configuration
+  enable_https               = true
+  domain_name               = "api-dev.inkomoko.com"
+  subject_alternative_names = ["dev.inkomoko.com"]
+  route53_zone_id           = "Z1234567890ABC"  # Your Route53 zone ID
+  create_www_redirect       = true
+
+  tags = local.tags
+}
+```
+
+### Step 2: DNS Configuration
+
+1. **Create Route53 Hosted Zone** (if not exists):
+   ```bash
+   aws route53 create-hosted-zone \
+     --name inkomoko.com \
+     --caller-reference $(date +%s)
+   ```
+
+2. **Update Domain Nameservers**:
+   - Copy the nameservers from Route53 hosted zone
+   - Update your domain registrar's nameserver settings
+
+### Step 3: Certificate Validation
+
+The Terraform configuration will:
+1. Create an ACM certificate
+2. Add DNS validation records to Route53
+3. Wait for certificate validation
+4. Configure ALB with the validated certificate
+
+### Step 4: Docker Image Configuration
+
+Update your environment variables to use the latest image:
+
+```hcl
+module "compute" {
+  source = "../../modules/compute"
+
+  # ... other configuration ...
+
+  docker_image_url = "ghcr.io/blue-davinci/inkomoko"  # Will pull latest tag
+}
+```
+
+## Security Best Practices
+
+### 1. SSL/TLS Configuration
+- **TLS Version**: Uses `ELBSecurityPolicy-TLS-1-2-2017-01` (configurable)
+- **Certificate Type**: RSA 2048-bit (ACM default)
+- **Validation**: DNS validation (automated)
+
+### 2. HTTPS Redirection
+- All HTTP traffic (port 80) redirects to HTTPS (port 443)
+- Uses 301 permanent redirect for SEO benefits
+
+### 3. Security Headers
+The nginx configuration includes:
+```nginx
+add_header X-Frame-Options DENY;
+add_header X-Content-Type-Options nosniff;
+add_header X-XSS-Protection "1; mode=block";
+add_header Referrer-Policy "strict-origin-when-cross-origin";
+```
+
+### 4. Rate Limiting
+```nginx
+limit_req_zone $remote_addr zone=api_limit:10m rate=10r/s;
+limit_req zone=api_limit burst=20 nodelay;
+```
+
+## Monitoring and Logging
+
+### 1. CloudWatch Integration
+- Container logs automatically sent to CloudWatch
+- Log retention: 7 days (configurable)
+- Log groups:
+  - `/aws/ec2/inkomoko` - Application logs
+  - `/aws/ec2/user-data` - Deployment logs
+
+### 2. Health Checks
+- ALB health check: `/health` endpoint
+- Health check interval: 30 seconds
+- Healthy threshold: 2 consecutive successes
+- Unhealthy threshold: 3 consecutive failures
+
+## Deployment Process
+
+### 1. Infrastructure Deployment
+```bash
+cd depoyment/terraform/environments/dev
+terraform init
+terraform plan
+terraform apply
+```
+
+### 2. Certificate Validation
+- ACM certificate creation: ~2-5 minutes
+- DNS validation: ~5-10 minutes
+- Total setup time: ~10-15 minutes
+
+### 3. Application Deployment
+- Docker image pulled automatically during EC2 launch
+- Auto Scaling Group ensures high availability
+- Rolling updates via ASG launch template
+
+## Production Considerations
+
+### 1. Environment Separation
+- **Development**: `api-dev.inkomoko.com`
+- **Staging**: `api-staging.inkomoko.com`
+- **Production**: `api.inkomoko.com`
+
+### 2. Certificate Management
+- ACM handles automatic renewal (60 days before expiry)
+- No manual intervention required
+- Validation records remain in Route53
+
+### 3. Backup Domain Strategy
+```hcl
+subject_alternative_names = [
+  "api-backup.inkomoko.com",
+  "www.api.inkomoko.com"
+]
+```
+
+### 4. Multi-Region Setup
+For production resilience:
+- Primary region: us-east-1
+- Secondary region: us-west-2
+- Route53 health checks for failover
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Certificate Validation Timeout**
+   - Check Route53 hosted zone ID
+   - Verify nameserver delegation
+   - Wait up to 10 minutes for DNS propagation
+
+2. **ALB Health Check Failures**
+   - Verify `/health` endpoint returns 200
+   - Check security group allows ALB to EC2 communication
+   - Review CloudWatch logs for application errors
+
+3. **Docker Image Pull Failures**
+   - Verify image exists in registry
+   - Check IAM permissions for ECR access
+   - Review user-data logs in CloudWatch
+
+### Monitoring Commands
+```bash
+# Check certificate status
+aws acm describe-certificate --certificate-arn <cert-arn>
+
+# Check ALB target health
+aws elbv2 describe-target-health --target-group-arn <tg-arn>
+
+# Check application logs
+aws logs tail /aws/ec2/inkomoko --follow
+```
+
+## Cost Optimization
+
+### 1. Certificate Costs
+- ACM certificates: **FREE**
+- Route53 hosted zone: **$0.50/month**
+- DNS queries: **$0.40/million queries**
+
+### 2. ALB Costs
+- ALB base cost: **~$16/month**
+- Load Balancer Capacity Units (LCU): **$0.008/hour**
+
+### 3. Monitoring Costs
+- CloudWatch Logs: **$0.50/GB ingested**
+- Log retention: 7 days (minimal cost)
+
+## Next Steps
+
+1. **WAF Integration**: Add AWS WAF for advanced security
+2. **CloudFront**: Add CDN for global performance
+3. **Monitoring**: Implement comprehensive monitoring with CloudWatch/Grafana
+4. **Backup Strategy**: Implement automated backup solutions
+5. **Disaster Recovery**: Set up multi-region deployment
+
+## Security Checklist
+
+- [ ] Domain validated certificate
+- [ ] HTTPS-only access (HTTP redirects)
+- [ ] Security headers configured
+- [ ] Rate limiting enabled
+- [ ] VPC security groups properly configured
+- [ ] IAM roles follow least privilege
+- [ ] CloudWatch logging enabled
+- [ ] Health checks configured
+- [ ] Auto Scaling configured
+- [ ] Backup strategy implemented

--- a/docs/QUICK_HTTPS_SETUP.md
+++ b/docs/QUICK_HTTPS_SETUP.md
@@ -1,0 +1,196 @@
+# Quick Setup Guide for InkoMoko
+
+## 🚀 Current Status
+✅ **HTTP-only setup** - Your infrastructure is ready and working without SSL
+✅ **HTTPS-ready** - SSL/TLS configuration is prepared but disabled
+✅ **Latest Docker images** - Automatic deployment from GitHub Container Registry
+
+## 1️⃣ Deploy HTTP-only (Recommended First Step)
+
+### Why Start with HTTP?
+- ✅ **Works immediately** - No domain setup required
+- ✅ **Test your application** - Verify everything works before adding SSL
+- ✅ **No additional cost** - HTTP testing is free
+- ✅ **Easy HTTPS upgrade** - Add domain later when ready
+
+### Deploy Now
+```bash
+cd depoyment/terraform/environments/dev
+terraform apply plan.out
+```
+
+### Test Your Deployment
+```bash
+# Get your ALB URL
+ALB_URL=$(terraform output -raw alb_dns_name)
+echo "Your application is available at: http://$ALB_URL"
+
+# Test health endpoint
+curl http://$ALB_URL/health
+
+# Test API endpoint
+curl http://$ALB_URL/v1/
+```
+
+### What You Get
+- **Load Balancer**: Highly available ALB
+- **Auto Scaling**: 2-3 EC2 instances based on load
+- **Latest Docker Images**: Automatically pulls from `ghcr.io/blue-davinci/inkomoko:latest`
+- **CloudWatch Logging**: Full observability
+- **Security Groups**: Properly configured network isolation
+
+## 2️⃣ Add HTTPS Later (When You Have a Domain)
+
+### Prerequisites for HTTPS
+- 🌐 **Own a domain** (e.g., `example.com`)
+- 📋 **Route53 hosted zone** for your domain
+- 🔗 **Updated nameservers** pointing to Route53
+
+### Quick HTTPS Activation
+
+1. **Add variables to `terraform.tfvars`**:
+```hcl
+enable_https = true
+domain_name = "api.yourdomain.com"  # Replace with your domain
+route53_zone_id = "Z1234567890ABC"   # Your Route53 hosted zone ID
+```
+
+2. **Update `main.tf`**:
+```hcl
+module "alb" {
+  source = "../../modules/alb"
+
+  # Existing configuration...
+  alb_name            = "my-alb-${var.environment}"
+  subnet_ids          = module.networking.public_subnet_ids_list
+  vpc_id              = module.networking.vpc_id
+  tags                = var.tags
+  enable_alb_deletion = var.enable_alb_deletion
+
+  # Add HTTPS configuration
+  enable_https     = var.enable_https
+  domain_name      = var.domain_name
+  route53_zone_id  = var.route53_zone_id
+}
+```
+
+3. **Add variables to `variables.tf`**:
+```hcl
+variable "enable_https" {
+  description = "Whether to enable HTTPS with SSL certificate"
+  type        = bool
+  default     = false
+}
+
+variable "domain_name" {
+  description = "The primary domain name for SSL certificate"
+  type        = string
+  default     = ""
+}
+
+variable "route53_zone_id" {
+  description = "Route53 hosted zone ID for DNS validation"
+  type        = string
+  default     = ""
+}
+```
+
+4. **Deploy HTTPS**:
+```bash
+terraform plan
+terraform apply
+```
+
+## 🔄 What Happens When You Enable HTTPS
+
+### Automatic SSL Setup (5-15 minutes)
+1. **ACM Certificate** - Created automatically for your domain
+2. **DNS Validation** - Route53 records added automatically
+3. **Certificate Validation** - AWS validates domain ownership
+4. **ALB Configuration** - HTTPS listener added with certificate
+5. **HTTP Redirect** - All HTTP traffic redirects to HTTPS
+
+### After HTTPS is Enabled
+- ✅ **Your domain works**: `https://api.yourdomain.com/health`
+- ✅ **HTTP redirects**: `http://api.yourdomain.com` → `https://`
+- ✅ **Auto-renewal**: AWS handles certificate renewal
+- ✅ **Security headers**: Production security enabled
+
+## 🎯 Recommended Path
+
+### Phase 1: Test HTTP (Now - 5 minutes)
+```bash
+terraform apply plan.out
+curl http://$(terraform output -raw alb_dns_name)/health
+```
+
+### Phase 2: Get Domain (When Ready)
+- Purchase domain from any registrar
+- Create Route53 hosted zone
+- Update domain nameservers
+
+### Phase 3: Enable HTTPS (5 minutes)
+- Add domain variables
+- Run `terraform apply`
+- Access via `https://yourdomain.com`
+
+## 🔍 Troubleshooting
+
+### Common Issues
+
+**❌ "This site can't provide a secure connection"**
+- You're trying to access ALB DNS with HTTPS
+- Solution: Use HTTP with ALB DNS, or set up custom domain
+
+**❌ Certificate validation timeout**
+- Check domain nameservers point to Route53
+- Wait up to 10 minutes for DNS propagation
+
+**❌ Health check failures**
+- Check if `/health` endpoint returns 200
+- Review CloudWatch logs: `/aws/ec2/inkomoko`
+
+### Monitoring Commands
+```bash
+# Check infrastructure status
+terraform output
+
+# Check application logs
+aws logs tail /aws/ec2/inkomoko --follow
+
+# Check ALB target health
+aws elbv2 describe-target-health --target-group-arn $(terraform output -raw target_group_arn)
+```
+
+## 💰 Cost Breakdown
+
+### HTTP-only Testing
+- **ALB**: ~$16/month
+- **EC2 (t2.micro x2)**: ~$17/month
+- **Data Transfer**: Minimal
+- **Total**: ~$33/month
+
+### HTTPS Addition
+- **SSL Certificate**: **FREE** (AWS ACM)
+- **Route53 Hosted Zone**: $0.50/month
+- **DNS Queries**: $0.40/million queries
+- **Additional Cost**: ~$1/month
+
+## 🔐 Security Features
+
+### Current (HTTP)
+- ✅ VPC isolation
+- ✅ Private subnets for EC2
+- ✅ Security groups restricting access
+- ✅ CloudWatch logging
+- ✅ IAM roles with least privilege
+
+### With HTTPS
+- ✅ **All of the above, plus:**
+- ✅ End-to-end encryption
+- ✅ Automatic HTTP→HTTPS redirect
+- ✅ Security headers (XSS protection, etc.)
+- ✅ Rate limiting
+- ✅ Modern TLS policies
+
+Your infrastructure is **production-ready** right now! 🎉


### PR DESCRIPTION
- Added capability to shift between http and https via flags
- Added capability for HTTPs mode i.e.:
 > ALB accepts https on 443, and terminates ssl
 > Forwards decrypted http to ASHs on port 80 via nginx target
 > UPdated security group configs to match the above change
- Added detailed documentation including a https implementation guide, quick setup guide and info hook on READMEmd to conect it all.
> Updated our install script to now pull correct docker files as well as correct handling of errors that may occur
- Added better login fto our setup script.